### PR TITLE
Fix database setup instructions

### DIFF
--- a/src/ORM/README.md
+++ b/src/ORM/README.md
@@ -20,10 +20,11 @@ specify a driver to use:
 ```php
 use Cake\Datasource\ConnectionManager;
 
-ConnectionManager::create('default', [
+ConnectionManager::config('default', [
+	'className' => 'Cake\Database\Connection',
 	'driver' => 'Cake\Database\Driver\Mysql',
 	'database' => 'test',
-	'login' => 'root',
+	'username' => 'root',
 	'password' => 'secret'
 ]);
 ```


### PR DESCRIPTION
When trying to use the 3.0 ORM outside of CakePHP I ran into problems when following the instructions provided in the README.  This fixes those instructions.

config() seems to be the correct method to use, not create() which doesn't exist. Also had to add 'className' and change 'login' to 'username'.